### PR TITLE
Fix static language routes build failure

### DIFF
--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -7,6 +7,12 @@ type TranslationKey = keyof typeof resume.translations;
 const languages = resume.languages;
 const translationKeys = Object.keys(resume.translations) as TranslationKey[];
 const defaultLanguage = (languages[0]?.code as TranslationKey) ?? translationKeys[0];
+export function getStaticPaths() {
+  return resume.languages.map(({ code }) => ({
+    params: { lang: code },
+  }));
+}
+
 const requestedLangParam = Astro.params.lang;
 const requestedLang = translationKeys.find((code) => code === requestedLangParam) as TranslationKey | undefined;
 


### PR DESCRIPTION
## Summary
- add getStaticPaths implementation for language-specific home pages
- ensure Astro builds language routes using configured resume language codes

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c859186a48333a783f32971a84930)